### PR TITLE
Fix build issues on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ foreach(RESOURCE ${RESOURCE_FILES})
         OUTPUT ${HEADER_NAME}
         COMMAND xxd -i ${RESOURCE} > ${HEADER_NAME}.tmp
         COMMAND sed "s/unsigned char .* =/unsigned char ${BINARY_VAR_NAME}[] =/g" ${HEADER_NAME}.tmp > ${HEADER_NAME}
-        COMMAND sed "s/unsigned int .*_len =/unsigned int ${BINARY_VAR_NAME}_len =/g" ${HEADER_NAME} -i
+        COMMAND sed -i '' "s/unsigned int .*_len =/unsigned int ${BINARY_VAR_NAME}_len =/g" ${HEADER_NAME}
         COMMAND rm -f ${HEADER_NAME}.tmp
         DEPENDS ${RESOURCE}
         COMMENT "Embedding ${RESOURCE} as ${HEADER_NAME}"

--- a/src/SineLookupTable.h
+++ b/src/SineLookupTable.h
@@ -6,7 +6,7 @@ constexpr float TWO_PI = 6.28318530718f;
 template <size_t N>
 class SineLookupTable {
 public:
-    static constexpr std::array<float, N> generateSineLookup() {
+    static std::array<float, N> generateSineLookup() {
         std::array<float, N> lookupTable = {};
         for (size_t i = 0; i < N; ++i) {
             lookupTable[i] = std::sin(TWO_PI * i / N);
@@ -14,5 +14,5 @@ public:
         return lookupTable;
     }
 
-    static constexpr std::array<float, N> table = generateSineLookup();
+    static inline std::array<float, N> table = generateSineLookup();
 };


### PR DESCRIPTION
This PR fixes two build issues that prevent compilation on macOS:

## Issues Fixed

1. **sed -i syntax in CMakeLists.txt**: macOS sed requires an empty string argument with the -i flag (`sed -i ''` instead of `sed -i`)

2. **constexpr std::sin in SineLookupTable.h**: `std::sin` is not constexpr on macOS/AppleClang. Changed from `static constexpr` to `static inline` to maintain single instance behavior while allowing runtime initialization.

## Testing

Tested on macOS 14.3 (Sonoma) with AppleClang 17.0.0:
- ✅ Build succeeds with `./build.sh`
- ✅ All tests pass
- ✅ Game executable runs correctly

## Changes

- `CMakeLists.txt`: Line 59 - Add empty string to `sed -i` for macOS compatibility
- `src/SineLookupTable.h`: Lines 9, 17 - Remove `constexpr`, use `static inline` instead